### PR TITLE
Add, update, delete data query definitions

### DIFF
--- a/backend/src/GroundTruthCuration.Api/Controllers/GroundTruthController.cs
+++ b/backend/src/GroundTruthCuration.Api/Controllers/GroundTruthController.cs
@@ -97,7 +97,31 @@ public class GroundTruthController : ControllerBase
     {
         try
         {
-            var result = await _groundTruthCurationService.AddGroundTruthContextsAndRelatedEntitiesAsync(id, contexts);
+            var result = await _groundTruthCurationService.UpdateGroundTruthContextsAndRelatedEntitiesAsync(id, contexts);
+
+            if (result == null)
+            {
+                return NotFound($"Ground truth definition with ID {id} not found.");
+            }
+
+            return Ok(result);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, $"Internal server error: {ex.Message}");
+        }
+    }
+
+    [HttpPut("definition/{id}/data-queries")]
+    public async Task<ActionResult<GroundTruthDefinitionDto>> UpdateDataQueries(Guid id, [FromBody] List<DataQueryDefinitionDto> dataQueries)
+    {
+        try
+        {
+            var result = await _groundTruthCurationService.UpdateGroundTruthDataQueryDefinitionsAsync(id, dataQueries);
 
             if (result == null)
             {

--- a/backend/src/GroundTruthCuration.Api/Program.cs
+++ b/backend/src/GroundTruthCuration.Api/Program.cs
@@ -53,9 +53,11 @@ builder.Services.AddSingleton<DatastoreRepositoryResolver>(serviceProvider => ke
 builder.Services.AddScoped<IStatusService, StatusService>();
 builder.Services.AddScoped<IGroundTruthCurationService, GroundTruthCurationService>();
 builder.Services.AddScoped<IGroundTruthMapper<GroundTruthDefinition, GroundTruthDefinitionDto>, GroundTruthDefinitionToDtoMapper>();
+builder.Services.AddScoped<IGroundTruthMapper<DataQueryDefinitionDto, DataQueryDefinition>, DataQueryDefinitionDtoToEntityMapper>();
 builder.Services.AddScoped<ITagService, TagService>();
 builder.Services.AddScoped<IGroundTruthComparer<ContextParameterDto, ContextParameter>, ContextParameterComparer>();
 builder.Services.AddScoped<IGroundTruthComparer<GroundTruthContextDto, GroundTruthContext>, GroundTruthContextComparer>();
+builder.Services.AddScoped<IGroundTruthComparer<DataQueryDefinitionDto, DataQueryDefinition>, DataQueryComparer>();
 
 // Background job processing registrations,
 // be sure to register IBackgroundJobExecutors before the rest of the job services

--- a/backend/src/GroundTruthCuration.Core/DTOs/DataQueryDefinitionDto.cs
+++ b/backend/src/GroundTruthCuration.Core/DTOs/DataQueryDefinitionDto.cs
@@ -12,7 +12,7 @@ public class DataQueryDefinitionDto
     /// <summary>
     /// Gets or sets the identifier of the associated ground truth definition.
     /// </summary>
-    public required Guid GroundTruthId { get; set; }
+    public Guid? GroundTruthId { get; set; }
 
     /// <summary>
     /// Gets or sets the type of datastore (e.g., SQL, CosmosDb).
@@ -58,5 +58,5 @@ public class DataQueryDefinitionDto
     /// <summary>
     /// Gets or sets the date and time when this query definition was created.
     /// </summary>
-    public DateTime CreationDateTime { get; set; }
+    public DateTime? CreationDateTime { get; set; }
 }

--- a/backend/src/GroundTruthCuration.Core/Interfaces/Repositories/IGroundTruthRepository.cs
+++ b/backend/src/GroundTruthCuration.Core/Interfaces/Repositories/IGroundTruthRepository.cs
@@ -94,4 +94,26 @@ public interface IGroundTruthRepository
     /// <param name="updatedContext"></param>
     /// <returns></returns>
     Task UpdateGroundTruthContextAndRelatedEntitiesAsync(Guid groundTruthId, GroundTruthContext updatedContext);
+
+    /// <summary>
+    /// Removes data query definitions associated with a specific ground truth definition. 
+    /// This method ensures that all specified data query definitions are deleted in a single transaction to maintain data integrity.
+    /// </summary>
+    /// <param name="dataQueryIds"></param>
+    /// <returns></returns>
+    Task DeleteDataQueryDefinitionsAsync(IEnumerable<Guid> dataQueryIds);
+
+    /// <summary>
+    /// Updates an existing data query definition associated with a specific ground truth definition.
+    /// </summary>
+    /// <param name="dataQueryDefinition"></param>
+    /// <returns></returns>
+    Task UpdateDataQueryDefinitionAsync(DataQueryDefinition dataQueryDefinition);
+
+    /// <summary>
+    /// Adds a new data query definition associated with a specific ground truth definition.
+    /// </summary>
+    /// <param name="dataQueryDefinition"></param>
+    /// <returns></returns>
+    Task AddDataQueryDefinitionAsync(DataQueryDefinition dataQueryDefinition);
 }

--- a/backend/src/GroundTruthCuration.Core/Interfaces/Services/IGroundTruthCurationService.cs
+++ b/backend/src/GroundTruthCuration.Core/Interfaces/Services/IGroundTruthCurationService.cs
@@ -30,23 +30,24 @@ namespace GroundTruthCuration.Core.Interfaces
         /// </summary>
         /// <param name="groundTruthDefinition">The ground truth definition to add.</param>
         /// <returns>The added ground truth definition.</returns>
-        Task<GroundTruthDefinitionDto> AddGroundTruthDefinitionAsync(GroundTruthDefinitionDto groundTruthDefinition);
+        Task<GroundTruthDefinitionDto?> AddGroundTruthDefinitionAsync(GroundTruthDefinitionDto groundTruthDefinition);
 
         /// <summary>
-        /// Updates an existing ground truth definition in the repository.
+        /// Adds, updates, or removes data query definitions associated with a ground truth definition in the repository.
         /// </summary>
         /// <param name="groundTruthId">The unique identifier of the ground truth definition to update.</param>
         /// <param name="dataQueryDefinitions">The updated list of data query definitions.</param>
         /// <returns>The updated ground truth definition.</returns>
-        Task<GroundTruthDefinitionDto> UpdateGroundTruthDataQueryDefinitionsAsync(Guid groundTruthId, List<DataQueryDefinitionDto> dataQueryDefinitions);
+        Task<GroundTruthDefinitionDto?> UpdateGroundTruthDataQueryDefinitionsAsync(Guid groundTruthId, List<DataQueryDefinitionDto> dataQueryDefinitions);
 
         /// <summary>
-        /// Adds a new ground truth context to an existing ground truth definition.
+        /// Adds, updates, or removes ground truth contexts and related entities for an existing ground truth definition.
+        /// The result will be an updated ground truth definition that reflects the changes.
         /// </summary>
-        /// <param name="groundTruthId">The unique identifier of the ground truth definition to which the context will be added.</param>
-        /// <param name="groundTruthContexts">The ground truth contexts to add.</param>
-        /// <returns>The updated ground truth definition with the new contexts.</returns>
-        Task<GroundTruthDefinitionDto?> AddGroundTruthContextsAndRelatedEntitiesAsync(Guid groundTruthId, List<GroundTruthContextDto> groundTruthContexts);
+        /// <param name="groundTruthId">The unique identifier of the ground truth definition to update.</param>
+        /// <param name="groundTruthContexts">The updated list of ground truth contexts.</param>
+        /// <returns>The updated ground truth definition.</returns>
+        Task<GroundTruthDefinitionDto?> UpdateGroundTruthContextsAndRelatedEntitiesAsync(Guid groundTruthId, List<GroundTruthContextDto> groundTruthContexts);
 
         /// <summary>
         /// Deletes a ground truth definition from the repository by its unique identifier.

--- a/backend/src/GroundTruthCuration.Core/Services/GroundTruthCurationService.cs
+++ b/backend/src/GroundTruthCuration.Core/Services/GroundTruthCurationService.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using System.Text.Json;
 
 namespace GroundTruthCuration.Core.Services
 {
@@ -19,7 +20,9 @@ namespace GroundTruthCuration.Core.Services
         private readonly ILogger<GroundTruthCurationService> _logger;
         private readonly IGroundTruthRepository _groundTruthRepository;
         private readonly IGroundTruthMapper<GroundTruthDefinition, GroundTruthDefinitionDto> _groundTruthDefinitionToDtoMapper;
+        private readonly IGroundTruthMapper<DataQueryDefinitionDto, DataQueryDefinition> _dataQueryFromDtoMapper;
         private readonly IGroundTruthComparer<GroundTruthContextDto, GroundTruthContext> _contextComparer;
+        private readonly IGroundTruthComparer<DataQueryDefinitionDto, DataQueryDefinition> _dataQueryComparer;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GroundTruthCurationService"/> class.
@@ -28,16 +31,24 @@ namespace GroundTruthCuration.Core.Services
         /// <param name="groundTruthRepository">The repository for managing ground truth data.</param>
         /// <param name="groundTruthDefinitionToDtoMapper">The mapper for converting ground truth definitions to DTOs.</param>
         /// <param name="contextComparer">The comparer for validating context data consistency.</param>
-        public GroundTruthCurationService(ILogger<GroundTruthCurationService> logger, IGroundTruthRepository groundTruthRepository, IGroundTruthMapper<GroundTruthDefinition, GroundTruthDefinitionDto> groundTruthDefinitionToDtoMapper, IGroundTruthComparer<GroundTruthContextDto, GroundTruthContext> contextComparer)
+        /// <param name="dataQueryComparer">The comparer for validating data query definitions.</param>
+        /// <param name="dataQueryFromDtoMapper"></param>
+        public GroundTruthCurationService(ILogger<GroundTruthCurationService> logger, IGroundTruthRepository groundTruthRepository,
+            IGroundTruthMapper<GroundTruthDefinition, GroundTruthDefinitionDto> groundTruthDefinitionToDtoMapper,
+            IGroundTruthComparer<GroundTruthContextDto, GroundTruthContext> contextComparer,
+            IGroundTruthComparer<DataQueryDefinitionDto, DataQueryDefinition> dataQueryComparer,
+            IGroundTruthMapper<DataQueryDefinitionDto, DataQueryDefinition> dataQueryFromDtoMapper)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _groundTruthRepository = groundTruthRepository ?? throw new ArgumentNullException(nameof(groundTruthRepository));
             _groundTruthDefinitionToDtoMapper = groundTruthDefinitionToDtoMapper ?? throw new ArgumentNullException(nameof(groundTruthDefinitionToDtoMapper));
             _contextComparer = contextComparer ?? throw new ArgumentNullException(nameof(contextComparer));
+            _dataQueryComparer = dataQueryComparer ?? throw new ArgumentNullException(nameof(dataQueryComparer));
+            _dataQueryFromDtoMapper = dataQueryFromDtoMapper ?? throw new ArgumentNullException(nameof(dataQueryFromDtoMapper));
         }
 
         /// <inheritdoc/>
-        public async Task<GroundTruthDefinitionDto?> AddGroundTruthContextsAndRelatedEntitiesAsync(Guid groundTruthId, List<GroundTruthContextDto> groundTruthContexts)
+        public async Task<GroundTruthDefinitionDto?> UpdateGroundTruthContextsAndRelatedEntitiesAsync(Guid groundTruthId, List<GroundTruthContextDto> groundTruthContexts)
         {
             // Get the existing ground truth definition
             var groundTruthDefinition = await _groundTruthRepository.GetGroundTruthDefinitionByIdAsync(groundTruthId);
@@ -45,7 +56,7 @@ namespace GroundTruthCuration.Core.Services
             if (groundTruthDefinition == null)
             {
                 _logger.LogError("Ground truth definition with ID {GroundTruthId} not found.", groundTruthId);
-                return null;
+                return null; // Explicitly returning null for nullable return type
             }
 
             foreach (var contextDto in groundTruthContexts)
@@ -140,9 +151,104 @@ namespace GroundTruthCuration.Core.Services
         }
 
         /// <inheritdoc/>
-        public Task<GroundTruthDefinitionDto> UpdateGroundTruthDataQueryDefinitionsAsync(Guid groundTruthId, List<DataQueryDefinitionDto> dataQueryDefinitions)
+        public async Task<GroundTruthDefinitionDto?> UpdateGroundTruthDataQueryDefinitionsAsync(Guid groundTruthId, List<DataQueryDefinitionDto> dataQueryDefinitions)
         {
-            throw new NotImplementedException();
+            // get existing ground truth definition
+            var groundTruthDefinition = await _groundTruthRepository.GetGroundTruthDefinitionByIdAsync(groundTruthId);
+            if (groundTruthDefinition == null)
+            {
+                _logger.LogError("Ground truth definition with ID {GroundTruthId} not found. Aborting data query definition updates.", groundTruthId);
+                return null;
+            }
+
+            // determine definitions to remove
+            var existingDataQueryIds = groundTruthDefinition.DataQueryDefinitions
+                .Select(dq => dq.DataQueryId)
+                .ToHashSet();
+
+            var incomingDataQueryIds = dataQueryDefinitions
+                .Select(dq => dq.DataQueryId ?? Guid.Empty) // Treat null as empty
+                .Where(id => id != Guid.Empty) // Exclude empty GUIDs
+                .ToHashSet();
+
+            await deleteObsoleteDataQueriesAsync(existingDataQueryIds, incomingDataQueryIds);
+
+            // check for changes in existing definitions
+            foreach (var dataQueryDefinition in dataQueryDefinitions)
+            {
+                if (dataQueryDefinition.DataQueryId != null && existingDataQueryIds.Contains(dataQueryDefinition.DataQueryId.Value))
+                {
+                    await processExistingDataQueryAsync(groundTruthDefinition, dataQueryDefinition);
+                }
+                else
+                {
+                    await addNewDataQueryAsync(dataQueryDefinition, groundTruthId);
+                }
+            }
+
+            // TODO: execute data queries for new or updated definitions
+
+            // return updated ground truth definition
+            var updatedGroundTruthDefinition = await _groundTruthRepository.GetGroundTruthDefinitionByIdAsync(groundTruthId);
+            if (updatedGroundTruthDefinition == null)
+            {
+                _logger.LogError("Ground truth definition with ID {GroundTruthId} not found after data query updates.", groundTruthId);
+                return null;
+            }
+
+            return _groundTruthDefinitionToDtoMapper.Map(updatedGroundTruthDefinition);
+        }
+
+        private async Task deleteObsoleteDataQueriesAsync(HashSet<Guid> existingDataQueryIds, HashSet<Guid> incomingDataQueryIds)
+        {
+            var toRemove = existingDataQueryIds.Except(incomingDataQueryIds).ToList();
+            if (toRemove.Any())
+            {
+                await _groundTruthRepository.DeleteDataQueryDefinitionsAsync(toRemove);
+            }
+        }
+
+        private async Task processExistingDataQueryAsync(GroundTruthDefinition groundTruthDefinition, DataQueryDefinitionDto dataQueryDto)
+        {
+            // get the existing version
+            var existingDataQuery = groundTruthDefinition.DataQueryDefinitions
+                .FirstOrDefault(dq => dq.DataQueryId == dataQueryDto.DataQueryId);
+            if (existingDataQuery == null)
+            {
+                _logger.LogError("Inconsistent state: Data Query ID {DataQueryId} found in existing IDs but no matching entry.", dataQueryDto.DataQueryId);
+                return;
+            }
+
+            if (!_dataQueryComparer.HasSameValues(dataQueryDto, existingDataQuery))
+            {
+                _logger.LogInformation("Updating existing data query with ID {DataQueryId}", dataQueryDto.DataQueryId);
+
+                // convert to entity
+                var dataQueryEntity = _dataQueryFromDtoMapper.Map(dataQueryDto);
+
+                await _groundTruthRepository.UpdateDataQueryDefinitionAsync(dataQueryEntity);
+            }
+        }
+
+        private async Task addNewDataQueryAsync(DataQueryDefinitionDto dataQueryDto, Guid groundTruthId)
+        {
+            // Add new data query
+            var newDataQuery = new DataQueryDefinition
+            {
+                DataQueryId = dataQueryDto.DataQueryId ?? Guid.NewGuid(),
+                DatastoreName = dataQueryDto.DatastoreName,
+                DatastoreType = dataQueryDto.DatastoreType,
+                GroundTruthId = groundTruthId,
+                QueryDefinition = dataQueryDto.QueryDefinition,
+                QueryTarget = dataQueryDto.QueryTarget,
+                IsFullQuery = dataQueryDto.IsFullQuery,
+                RequiredPropertiesJson = JsonSerializer.Serialize(dataQueryDto.RequiredProperties),
+                UserCreated = dataQueryDto.UserCreated,
+                UserUpdated = dataQueryDto.UserUpdated,
+                CreationDateTime = DateTime.UtcNow
+            };
+
+            await _groundTruthRepository.AddDataQueryDefinitionAsync(newDataQuery);
         }
 
         private async Task deleteObsoleteContextsAsync(GroundTruthDefinition groundTruthDefinition, HashSet<Guid?> existingContextIds, HashSet<Guid> incomingContextIds)

--- a/backend/src/GroundTruthCuration.Core/Utilities/DataQueryComparer.cs
+++ b/backend/src/GroundTruthCuration.Core/Utilities/DataQueryComparer.cs
@@ -1,0 +1,32 @@
+using System.Text.Json.Nodes;
+using GroundTruthCuration.Core.DTOs;
+using GroundTruthCuration.Core.Entities;
+using GroundTruthCuration.Core.Interfaces;
+
+namespace GroundTruthCuration.Core.Utilities;
+
+public class DataQueryComparer : IGroundTruthComparer<DataQueryDefinitionDto, DataQueryDefinition>
+{
+    public bool HasSameValues(DataQueryDefinitionDto dto, DataQueryDefinition entity)
+    {
+        if (dto == null || entity == null)
+        {
+            return false;
+        }
+
+        // compare response required properties
+        if (dto.RequiredProperties.Any(prop => !entity.RequiredPropertiesJson.Contains(prop)))
+        {
+            return false;
+        }
+
+        return dto.DataQueryId == entity.DataQueryId &&
+               dto.DatastoreName == entity.DatastoreName &&
+               dto.DatastoreType == entity.DatastoreType &&
+               dto.QueryTarget == entity.QueryTarget &&
+               dto.IsFullQuery == entity.IsFullQuery &&
+               dto.GroundTruthId == entity.GroundTruthId &&
+               dto.IsFullQuery == entity.IsFullQuery &&
+               dto.QueryDefinition == entity.QueryDefinition;
+    }
+}

--- a/backend/src/GroundTruthCuration.Core/Utilities/DataQueryComparer.cs
+++ b/backend/src/GroundTruthCuration.Core/Utilities/DataQueryComparer.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Nodes;
 using GroundTruthCuration.Core.DTOs;
 using GroundTruthCuration.Core.Entities;
@@ -15,10 +16,17 @@ public class DataQueryComparer : IGroundTruthComparer<DataQueryDefinitionDto, Da
         }
 
         // compare response required properties
+        // all properties in dto must be in entity
         if (dto.RequiredProperties.Any(prop => !entity.RequiredPropertiesJson.Contains(prop)))
         {
             return false;
         }
+
+        // no properties in entity that are not in dto
+        var entityProperties = JsonNode.Parse(entity.RequiredPropertiesJson)?.AsArray().Select(n => n?.ToString()).ToHashSet();
+
+        if (entityProperties != null && dto.RequiredProperties != null && !entityProperties.SetEquals(dto.RequiredProperties))
+            return false;
 
         return dto.DataQueryId == entity.DataQueryId &&
                dto.DatastoreName == entity.DatastoreName &&

--- a/backend/src/GroundTruthCuration.Core/Utilities/DataQueryDefinitionDtoToEntityMapper.cs
+++ b/backend/src/GroundTruthCuration.Core/Utilities/DataQueryDefinitionDtoToEntityMapper.cs
@@ -1,0 +1,39 @@
+using GroundTruthCuration.Core.Entities;
+using GroundTruthCuration.Core.DTOs;
+using GroundTruthCuration.Core.Interfaces;
+using System.Text.Json;
+
+namespace GroundTruthCuration.Core.Utilities;
+
+public class DataQueryDefinitionDtoToEntityMapper : IGroundTruthMapper<DataQueryDefinitionDto, DataQueryDefinition>
+{
+    /// <summary>
+    /// Maps a DataQueryDefinitionDto to a DataQueryDefinition entity.
+    /// </summary>
+    /// <param name="dataQueryDto"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public DataQueryDefinition Map(DataQueryDefinitionDto dataQueryDto)
+    {
+        if (dataQueryDto == null)
+        {
+            throw new ArgumentNullException(nameof(dataQueryDto));
+        }
+
+        return new DataQueryDefinition
+        {
+            DataQueryId = dataQueryDto.DataQueryId.HasValue && dataQueryDto.DataQueryId.Value != Guid.Empty
+                ? dataQueryDto.DataQueryId.Value
+                : Guid.NewGuid(),
+            GroundTruthId = dataQueryDto.GroundTruthId,
+            DatastoreType = dataQueryDto.DatastoreType,
+            DatastoreName = dataQueryDto.DatastoreName,
+            QueryDefinition = dataQueryDto.QueryDefinition,
+            QueryTarget = dataQueryDto.QueryTarget,
+            IsFullQuery = dataQueryDto.IsFullQuery,
+            RequiredPropertiesJson = JsonSerializer.Serialize(dataQueryDto.RequiredProperties),
+            UserCreated = dataQueryDto.UserCreated ?? string.Empty,
+            UserUpdated = dataQueryDto.UserUpdated ?? string.Empty,
+        };
+    }
+}

--- a/backend/src/GroundTruthCuration.Core/Utilities/DataQueryDefinitionDtoToEntityMapper.cs
+++ b/backend/src/GroundTruthCuration.Core/Utilities/DataQueryDefinitionDtoToEntityMapper.cs
@@ -25,7 +25,7 @@ public class DataQueryDefinitionDtoToEntityMapper : IGroundTruthMapper<DataQuery
             DataQueryId = dataQueryDto.DataQueryId.HasValue && dataQueryDto.DataQueryId.Value != Guid.Empty
                 ? dataQueryDto.DataQueryId.Value
                 : Guid.NewGuid(),
-            GroundTruthId = dataQueryDto.GroundTruthId,
+            GroundTruthId = dataQueryDto.GroundTruthId ?? Guid.NewGuid(),
             DatastoreType = dataQueryDto.DatastoreType,
             DatastoreName = dataQueryDto.DatastoreName,
             QueryDefinition = dataQueryDto.QueryDefinition,

--- a/backend/src/GroundTruthCuration.Infrastructure/Repositories/GroundTruthRepository.cs
+++ b/backend/src/GroundTruthCuration.Infrastructure/Repositories/GroundTruthRepository.cs
@@ -318,6 +318,7 @@ public class GroundTruthRepository : IGroundTruthRepository
                     await connection.ExecuteAsync(
                             "DELETE FROM [dbo].[DATA_QUERY_DEFINITION] WHERE dataQueryId IN @dataQueryIds;",
                             new { dataQueryIds }, transaction);
+                    await transaction.CommitAsync();
                 }
             }
             catch (Exception ex)

--- a/backend/src/GroundTruthCuration.Infrastructure/Repositories/GroundTruthRepository.cs
+++ b/backend/src/GroundTruthCuration.Infrastructure/Repositories/GroundTruthRepository.cs
@@ -185,6 +185,150 @@ public class GroundTruthRepository : IGroundTruthRepository
         throw new NotImplementedException();
     }
 
+    /// <inheritdoc/>
+    public async Task AddDataQueryDefinitionAsync(DataQueryDefinition dataQueryDefinition)
+    {
+        if (dataQueryDefinition == null)
+        {
+            throw new ArgumentNullException(nameof(dataQueryDefinition), "The data query definition cannot be null.");
+        }
+        if (dataQueryDefinition.GroundTruthId == Guid.Empty)
+        {
+            throw new ArgumentException("The ground truth ID in the data query definition cannot be an empty GUID.", nameof(dataQueryDefinition));
+        }
+
+        using (var connection = new SqlConnection(_connectionString))
+        {
+            await connection.OpenAsync();
+            using (var transaction = await connection.BeginTransactionAsync())
+            {
+                try
+                {
+                    string sql = @"
+                        INSERT INTO [dbo].[DATA_QUERY_DEFINITION] (dataQueryId, groundTruthId, datastoreType, datastoreName, queryTarget, 
+                            queryDefinition, isFullQuery, requiredPropertiesJson, userCreated, userUpdated, creationDateTime, 
+                            startDateTime, endDateTime)
+                        VALUES (@DataQueryId, @GroundTruthId, @DatastoreType, @DatastoreName, @QueryTarget, 
+                            @QueryDefinition, @IsFullQuery, @RequiredPropertiesJson, @UserCreated, @UserUpdated, @CreationDateTime, 
+                            @StartDateTime, @EndDateTime);";
+
+                    await connection.ExecuteAsync(sql, new
+                    {
+                        dataQueryDefinition.DataQueryId,
+                        dataQueryDefinition.GroundTruthId,
+                        dataQueryDefinition.DatastoreType,
+                        dataQueryDefinition.DatastoreName,
+                        dataQueryDefinition.QueryTarget,
+                        dataQueryDefinition.QueryDefinition,
+                        dataQueryDefinition.IsFullQuery,
+                        dataQueryDefinition.RequiredPropertiesJson,
+                        dataQueryDefinition.UserCreated,
+                        dataQueryDefinition.UserUpdated,
+                        dataQueryDefinition.CreationDateTime,
+                        dataQueryDefinition.StartDateTime,
+                        dataQueryDefinition.EndDateTime
+                    }, transaction);
+
+                    await transaction.CommitAsync();
+                }
+                catch (Exception ex)
+                {
+                    await transaction.RollbackAsync();
+                    _logger.LogError(ex, "Error adding data query definition.");
+                    throw new InvalidOperationException("An error occurred while adding the data query definition.", ex);
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task UpdateDataQueryDefinitionAsync(DataQueryDefinition dataQueryDefinition)
+    {
+        if (dataQueryDefinition == null)
+        {
+            throw new ArgumentNullException(nameof(dataQueryDefinition), "The data query definition cannot be null.");
+        }
+        if (dataQueryDefinition.DataQueryId == Guid.Empty)
+        {
+            throw new ArgumentException("The data query ID cannot be an empty GUID.", nameof(dataQueryDefinition));
+        }
+        if (dataQueryDefinition.GroundTruthId == Guid.Empty)
+        {
+            throw new ArgumentException("The ground truth ID in the data query definition cannot be an empty GUID.", nameof(dataQueryDefinition));
+        }
+
+        using (var connection = new SqlConnection(_connectionString))
+        {
+            await connection.OpenAsync();
+            using (var transaction = await connection.BeginTransactionAsync())
+            {
+                try
+                {
+                    string sql = @"
+                        UPDATE [dbo].[DATA_QUERY_DEFINITION]
+                        SET datastoreType = @DatastoreType,
+                            datastoreName = @DatastoreName,
+                            queryTarget = @QueryTarget,
+                            queryDefinition = @QueryDefinition,
+                            isFullQuery = @IsFullQuery,
+                            requiredPropertiesJson = @RequiredPropertiesJson,
+                            userUpdated = @UserUpdated
+                        WHERE dataQueryId = @DataQueryId AND groundTruthId = @GroundTruthId;";
+
+                    await connection.ExecuteAsync(sql, new
+                    {
+                        dataQueryDefinition.DatastoreType,
+                        dataQueryDefinition.DatastoreName,
+                        dataQueryDefinition.QueryTarget,
+                        dataQueryDefinition.QueryDefinition,
+                        dataQueryDefinition.IsFullQuery,
+                        dataQueryDefinition.RequiredPropertiesJson,
+                        dataQueryDefinition.UserUpdated,
+                        dataQueryDefinition.DataQueryId,
+                        dataQueryDefinition.GroundTruthId
+                    }, transaction);
+
+                    await transaction.CommitAsync();
+                }
+                catch (Exception ex)
+                {
+                    await transaction.RollbackAsync();
+                    _logger.LogError(ex, "Error updating data query definition with ID: {DataQueryId}", dataQueryDefinition.DataQueryId);
+                    throw new InvalidOperationException($"An error occurred while updating the data query definition with ID {dataQueryDefinition.DataQueryId}.", ex);
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task DeleteDataQueryDefinitionsAsync(IEnumerable<Guid> dataQueryIds)
+    {
+        if (dataQueryIds == null || !dataQueryIds.Any())
+        {
+            throw new ArgumentException("The data query IDs collection cannot be null or empty.", nameof(dataQueryIds));
+        }
+
+        using (var connection = new SqlConnection(_connectionString))
+        {
+            await connection.OpenAsync();
+            try
+            {
+                using (var transaction = await connection.BeginTransactionAsync())
+                {
+                    await connection.ExecuteAsync(
+                            "DELETE FROM [dbo].[DATA_QUERY_DEFINITION] WHERE dataQueryId IN @dataQueryIds;",
+                            new { dataQueryIds }, transaction);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error deleting data query definitions.");
+                throw new InvalidOperationException("An error occurred while deleting the data query definitions.", ex);
+            }
+        }
+    }
+
+    /// <inheritdoc/>
     public async Task AddGroundTruthContextAndRelatedEntitiesAsync(Guid groundTruthId, GroundTruthContext newContext)
     {
         if (groundTruthId == Guid.Empty)
@@ -258,6 +402,7 @@ public class GroundTruthRepository : IGroundTruthRepository
         }
     }
 
+    /// <inheritdoc/>
     public async Task DeleteGroundTruthContextsAndRelatedEntitiesAsync(Guid groundTruthId, IEnumerable<Guid> contextIds, IEnumerable<Guid> groundTruthEntryIds)
     {
         if (groundTruthId == Guid.Empty)
@@ -538,6 +683,7 @@ public class GroundTruthRepository : IGroundTruthRepository
 
         return parameters;
     }
+
 
     private static string baseSql = @"SELECT
         gtd.groundTruthId AS GroundTruthId,


### PR DESCRIPTION
This PR:
- Adds a `PUT` endpoint for adding, updating, deleting data query definitions for a ground truth definition
- The updated ground truth definition is returned
- Adds a check around processing existing entities so we don't add back items we just deleted